### PR TITLE
Update N3 tutorial link

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 ## Getting Started
 
-Please see the [N3 Tutorials](https://ngdenterprise.com/neo-tutorials/) site for quick start
+Please see the [N3 Tutorials](https://developers.neo.org/tutorials/2021/05/27/getting-started-with-the-neo-blockchain-toolkit) site for quick start
 videos and real world tutorials on using the latest version of the Neo Blockchain Toolkit.
 
 For developers targeting Neo Legacy, please see the [Neo Blockchain Toolkit Quickstart](https://github.com/neo-project/neo-blockchain-toolkit/blob/master/quickstart.md)

--- a/quickstart.md
+++ b/quickstart.md
@@ -1,7 +1,7 @@
 <!-- markdownlint-enable -->
 # Neo Blockchain Toolkit for .NET Quickstart
 
-> Note: this Quickstart is for developers targeting [Neo Legacy](https://medium.com/neo-smart-economy/introducing-neo-n3-the-next-evolution-of-the-neo-blockchain-b2960c4def6e). Developers developers targeting N3 should check out the new [N3 Tutorials](https://ngdenterprise.com/neo-tutorials/) site instead.
+> ⚠️ Note: this Quickstart is for developers targeting [Neo Legacy](https://medium.com/neo-smart-economy/introducing-neo-n3-the-next-evolution-of-the-neo-blockchain-b2960c4def6e). Developers developers targeting N3 should check out the new [N3 Tutorials](https://developers.neo.org/tutorials/2021/05/27/getting-started-with-the-neo-blockchain-toolkit) site instead.
 
 ## Prerequisites
 


### PR DESCRIPTION
The URL on this repository is linking to a 404 page.

But there is another problem: The page I linked has video tutorials that are not loading.